### PR TITLE
Replace misplaced SHA1 sum to the necessary SHA256 version

### DIFF
--- a/eclipse-java/PKGBUILD
+++ b/eclipse-java/PKGBUILD
@@ -36,7 +36,7 @@ sha256sums=('551872c0cede96248e45612f2d086dcf9f7b0c6160bb7da41a1799caa9071ee3'
 
 # override source for 32-bit
 [ "$CARCH" = "i686" ] && source[0]="http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/${_eclipse_name}/${_eclipse_release}/eclipse-java-${_eclipse_name}-${_eclipse_release}-linux-gtk.tar.gz"
-[ "$CARCH" = "i686" ] && sha256sums[0]='9274462776a02d4b40a344c1e7bace72a99ecdba'
+[ "$CARCH" = "i686" ] && sha256sums[0]='422509aa8dad5c2f524e450a0a97e05756794b70c50ac123b0397532e7edeedd'
 
 package() {
 	local _icon_path=/usr/share/eclipse/plugins/org.eclipse.platform_${pkgver}.v${_eclipse_timestamp}


### PR DESCRIPTION
For i686 arch, misplaced SHA1 sum was used in sha256sums array. Now fixed to correct SHA256 version.
