### PR TITLE
Fix vim modeline in PKGBUILD

### DIFF
--- a/nixnote-beta/PKGBUILD
+++ b/nixnote-beta/PKGBUILD
@@ -33,4 +33,4 @@ package()
 	cp -R "$srcdir/nixnote2/usr" "$pkgdir/"
 }
 
-# vim:set ts= 2 sw=2 Et:
+# vim:set ts=2 sw=2 Et:


### PR DESCRIPTION
No space is allowed after =
